### PR TITLE
Add book framework with outlines and notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ with install4j for Windows. Example:
 2. In **Preferences ▸ Gradle ▸ Synchronization** enable *Synchronize automatically after builds*.
 3. Launch the `app` run configuration from the Gradle Tasks view. While it runs under the debugger, editing a method signature in `library` and saving will trigger HotswapAgent to reload the class.
 4. For instant recompiles run `./gradlew -t classes` in the background so Eclipse picks up new class files immediately.
+
+## Cookbook Documentation
+
+The `book/` directory contains the structure for the *Gradle Cookbook*. Each chapter includes an outline and a Jupyter notebook so you can experiment with the code.

--- a/book/chapter-outline.md
+++ b/book/chapter-outline.md
@@ -1,0 +1,11 @@
+# Chapter Outline
+
+1. **Foundations of Gradle Multi-Project Builds**
+2. **Common Utilities Module**
+3. **Library Composition**
+4. **Data Access Layer**
+5. **Service Layer**
+6. **User Interface**
+7. **Packaging and Deployment**
+
+Each chapter includes a detailed outline and a companion Jupyter notebook under `book/chapters/`.

--- a/book/chapters/CH01/notebook.ipynb
+++ b/book/chapters/CH01/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 1: Foundations of Gradle Multi-Project Builds\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH01/outline.md
+++ b/book/chapters/CH01/outline.md
@@ -1,0 +1,6 @@
+# Chapter 1: Foundations of Gradle Multi-Project Builds
+
+* Project structure
+* Settings and build files
+* Running basic tasks
+* Using the Gradle Wrapper

--- a/book/chapters/CH02/notebook.ipynb
+++ b/book/chapters/CH02/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 2: Common Utilities Module\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH02/outline.md
+++ b/book/chapters/CH02/outline.md
@@ -1,0 +1,5 @@
+# Chapter 2: Common Utilities Module
+
+* Purpose of the `common` module
+* Example utilities and helper classes
+* Gradle dependencies between modules

--- a/book/chapters/CH03/notebook.ipynb
+++ b/book/chapters/CH03/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 3: Library Composition\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH03/outline.md
+++ b/book/chapters/CH03/outline.md
@@ -1,0 +1,5 @@
+# Chapter 3: Library Composition
+
+* Building a library on top of `common`
+* Exposing public APIs
+* Unit testing

--- a/book/chapters/CH04/notebook.ipynb
+++ b/book/chapters/CH04/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 4: Data Access Layer\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH04/outline.md
+++ b/book/chapters/CH04/outline.md
@@ -1,0 +1,5 @@
+# Chapter 4: Data Access Layer
+
+* Integrating external libraries
+* Reading and writing data
+* Gradle configurations for dependencies

--- a/book/chapters/CH05/notebook.ipynb
+++ b/book/chapters/CH05/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 5: Service Layer\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH05/outline.md
+++ b/book/chapters/CH05/outline.md
@@ -1,0 +1,5 @@
+# Chapter 5: Service Layer
+
+* Combining `data` and `library`
+* Designing a service API
+* Testing the service layer

--- a/book/chapters/CH06/notebook.ipynb
+++ b/book/chapters/CH06/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 6: User Interface\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH06/outline.md
+++ b/book/chapters/CH06/outline.md
@@ -1,0 +1,5 @@
+# Chapter 6: User Interface
+
+* Swing UI basics
+* Wiring the UI to the service layer
+* Hot reload with HotswapAgent

--- a/book/chapters/CH07/notebook.ipynb
+++ b/book/chapters/CH07/notebook.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chapter 7: Packaging and Deployment\n",
+    "This notebook contains interactive examples for the chapter."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/book/chapters/CH07/outline.md
+++ b/book/chapters/CH07/outline.md
@@ -1,0 +1,5 @@
+# Chapter 7: Packaging and Deployment
+
+* Building the final application
+* Docker support
+* Packaging scripts

--- a/book/foundations.md
+++ b/book/foundations.md
@@ -1,0 +1,7 @@
+# Foundations
+
+This document lays out the core concepts and foundation of the Gradle Cookbook project.
+
+The project demonstrates a modular Gradle build composed of multiple subprojects. Each module showcases an aspect of building a real-world application with Gradle, from common utilities up through the final runnable application.
+
+These foundations are the basis for the cookbook. The book chapters and accompanying notebooks build upon this structure.

--- a/book/learning-goals.md
+++ b/book/learning-goals.md
@@ -1,0 +1,6 @@
+# Learning Goals
+
+* Understand how Gradle structures a multi-project build.
+* Explore how each module contributes to a layered architecture.
+* Practice running and modifying the sample code in interactive notebooks.
+* Learn packaging and deployment techniques for a complete application.

--- a/book/overview.md
+++ b/book/overview.md
@@ -1,0 +1,3 @@
+# Gradle Cookbook Overview
+
+This repository contains the source code and learning materials for the *Gradle Cookbook*. The book walks through building a multi-project Gradle application step by step. Each chapter focuses on a layer of the application and is paired with an interactive Jupyter notebook that demonstrates the concepts in practice.


### PR DESCRIPTION
## Summary
- document the Gradle cookbook foundations and overview
- provide a chapter outline and learning goals
- add chapter outlines and starter Jupyter notebooks
- mention the cookbook in the main README

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_685a8054c6648321b97ec961ed5ca18c